### PR TITLE
Storage refactor: Copy powershell scripts from storage to vm.

### DIFF
--- a/virtual-machine/copy-managed-disks-to-same-or-different-subscription/copy-managed-disks-to-same-or-different-subscription.ps1
+++ b/virtual-machine/copy-managed-disks-to-same-or-different-subscription/copy-managed-disks-to-same-or-different-subscription.ps1
@@ -1,0 +1,30 @@
+#Provide the subscription Id of the subscription where managed disk exists
+$sourceSubscriptionId='yourSourceSubscriptionId'
+
+#Provide the name of your resource group where managed disk exists
+$sourceResourceGroupName='mySourceResourceGroupName'
+
+#Provide the name of the managed disk
+$managedDiskName='myDiskName'
+
+#Set the context to the subscription Id where Managed Disk exists
+Select-AzureRmSubscription -SubscriptionId $sourceSubscriptionId
+
+#Get the source managed disk
+$managedDisk= Get-AzureRMDisk -ResourceGroupName $sourceResourceGroupName -DiskName $managedDiskName
+
+#Provide the subscription Id of the subscription where managed disk will be copied to
+#If managed disk is copied to the same subscription then you can skip this step
+$targetSubscriptionId='yourTargetSubscriptionId'
+
+#Name of the resource group where snapshot will be copied to
+$targetResourceGroupName='myTargetResourceGroupName'
+
+#Set the context to the subscription Id where managed disk will be copied to
+#If snapshot is copied to the same subscription then you can skip this step
+Select-AzureRmSubscription -SubscriptionId $targetSubscriptionId
+
+$diskConfig = New-AzureRmDiskConfig -SourceResourceId $managedDisk.Id -Location $managedDisk.Location -CreateOption Copy 
+
+#Create a new managed disk in the target subscription and resource group
+New-AzureRmDisk -Disk $diskConfig -DiskName $managedDiskName -ResourceGroupName $targetResourceGroupName

--- a/virtual-machine/copy-snapshot-to-same-or-different-subscription/copy-snapshot-to-same-or-different-subscription.ps1
+++ b/virtual-machine/copy-snapshot-to-same-or-different-subscription/copy-snapshot-to-same-or-different-subscription.ps1
@@ -1,0 +1,30 @@
+#Provide the subscription Id of the subscription where snapshot exists
+$sourceSubscriptionId='yourSourceSubscriptionId'
+
+#Provide the name of your resource group where snapshot exists
+$sourceResourceGroupName='yourResourceGroupName'
+
+#Provide the name of the snapshot
+$snapshotName='yourSnapshotName'
+
+#Set the context to the subscription Id where snapshot exists
+Select-AzureRmSubscription -SubscriptionId $sourceSubscriptionId
+
+#Get the source snapshot
+$snapshot= Get-AzureRmSnapshot -ResourceGroupName $sourceResourceGroupName -Name $snapshotName
+
+#Provide the subscription Id of the subscription where snapshot will be copied to
+#If snapshot is copied to the same subscription then you can skip this step
+$targetSubscriptionId='yourTargetSubscriptionId'
+
+#Name of the resource group where snapshot will be copied to
+$targetResourceGroupName='yourTargetResourceGroupName'
+
+#Set the context to the subscription Id where snapshot will be copied to
+#If snapshot is copied to the same subscription then you can skip this step
+Select-AzureRmSubscription -SubscriptionId $targetSubscriptionId
+
+$snapshotConfig = New-AzureRmSnapshotConfig -SourceResourceId $snapshot.Id -Location $snapshot.Location -CreateOption Copy 
+
+#Create a new snapshot in the target subscription and resource group
+New-AzureRmSnapshot -Snapshot $snapshotConfig -SnapshotName $snapshotName -ResourceGroupName $targetResourceGroupName

--- a/virtual-machine/copy-snapshot-to-storage-account/copy-snapshot-to-storage-account.ps1
+++ b/virtual-machine/copy-snapshot-to-storage-account/copy-snapshot-to-storage-account.ps1
@@ -1,0 +1,37 @@
+#Provide the subscription Id of the subscription where snapshot is created
+$subscriptionId = "yourSubscriptionId"
+
+#Provide the name of your resource group where snapshot is created
+$resourceGroupName ="yourResourceGroupName"
+
+#Provide the snapshot name 
+$snapshotName = "yourSnapshotName"
+
+#Provide Shared Access Signature (SAS) expiry duration in seconds e.g. 3600.
+#Know more about SAS here: https://docs.microsoft.com/en-us/azure/storage/storage-dotnet-shared-access-signature-part-1
+$sasExpiryDuration = "3600"
+
+#Provide storage account name where you want to copy the snapshot. 
+$storageAccountName = "yourstorageaccountName"
+
+#Name of the storage container where the downloaded snapshot will be stored
+$storageContainerName = "yourstoragecontainername"
+
+#Provide the key of the storage account where you want to copy snapshot. 
+$storageAccountKey = 'yourStorageAccountKey'
+
+#Provide the name of the VHD file to which snapshot will be copied.
+$destinationVHDFileName = "yourvhdfilename"
+
+
+# Set the context to the subscription Id where Snapshot is created
+Select-AzureRmSubscription -SubscriptionId $SubscriptionId
+
+#Generate the SAS for the snapshot 
+$sas = Grant-AzureRmSnapshotAccess -ResourceGroupName $ResourceGroupName -SnapshotName $SnapshotName  -DurationInSecond $sasExpiryDuration -Access Read 
+ 
+#Create the context for the storage account which will be used to copy snapshot to the storage account 
+$destinationContext = New-AzureStorageContext –StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey  
+
+#Copy the snapshot to the storage account 
+Start-AzureStorageBlobCopy -AbsoluteUri $sas.AccessSAS -DestContainer $storageContainerName -DestContext $destinationContext -DestBlob $destinationVHDFileName

--- a/virtual-machine/create-managed-disk-from-snapshot/create-managed-disk-from-snapshot.ps1
+++ b/virtual-machine/create-managed-disk-from-snapshot/create-managed-disk-from-snapshot.ps1
@@ -1,0 +1,33 @@
+#Provide the subscription Id
+$subscriptionId = 'yourSubscriptionId'
+
+#Provide the name of your resource group
+$resourceGroupName ='yourResourceGroupName'
+
+#Provide the name of the snapshot that will be used to create Managed Disks
+$snapshotName = 'yourSnapshotName'
+
+#Provide the name of the Managed Disk
+$diskName = 'yourManagedDiskName'
+
+#Provide the size of the disks in GB. It should be greater than the VHD file size.
+$diskSize = '128'
+
+#Provide the storage type for Managed Disk. PremiumLRS or StandardLRS.
+$storageType = 'PremiumLRS'
+
+#Provide the Azure region (e.g. westus) where Managed Disks will be located.
+#This location should be same as the snapshot location
+#Get all the Azure location using command below:
+#Get-AzureRmLocation
+$location = 'westus'
+
+#Set the context to the subscription Id where Managed Disk will be created
+Select-AzureRmSubscription -SubscriptionId $SubscriptionId
+
+$snapshot = Get-AzureRmSnapshot -ResourceGroupName $resourceGroupName -SnapshotName $snapshotName 
+ 
+$diskConfig = New-AzureRmDiskConfig -AccountType $storageType -Location $location -CreateOption Copy -SourceResourceId $snapshot.Id
+ 
+New-AzureRmDisk -Disk $diskConfig -ResourceGroupName $resourceGroupName -DiskName $diskName
+ 

--- a/virtual-machine/create-managed-disks-from-vhd-in-different-subscription/create-managed-disks-from-vhd-in-different-subscription.ps1
+++ b/virtual-machine/create-managed-disks-from-vhd-in-different-subscription/create-managed-disks-from-vhd-in-different-subscription.ps1
@@ -1,0 +1,38 @@
+#Provide the subscription Id where Managed Disks will be created
+$subscriptionId = 'yourSubscriptionId'
+
+#Provide the name of your resource group where Managed Disks will be created. 
+$resourceGroupName ='yourResourceGroupName'
+
+#Provide the name of the Managed Disk
+$diskName = 'yourDiskName'
+
+#Provide the size of the disks in GB. It should be greater than the VHD file size.
+$diskSize = '128'
+
+#Provide the storage type for Managed Disk. PremiumLRS or StandardLRS.
+$storageType = 'PremiumLRS'
+
+#Provide the Azure region (e.g. westus) where Managed Disk will be located.
+#This location should be same as the storage account where VHD file is stored
+#Get all the Azure location using command below:
+#Get-AzureRmLocation
+$location = 'westus'
+
+#Provide the URI of the VHD file (page blob) in a storage account. Please not that this is NOT the SAS URI of the storage container where VHD file is stored. 
+#e.g. https://contosostorageaccount1.blob.core.windows.net/vhds/contosovhd123.vhd
+#Note: VHD file can be deleted as soon as Managed Disk is created.
+$sourceVHDURI = 'https://contosostorageaccount1.blob.core.windows.net/vhds/contosovhd123.vhd'
+
+#Provide the resource Id of the storage account where VHD file is stored.
+#e.g. /subscriptions/6472s1g8-h217-446b-b509-314e17e1efb0/resourceGroups/MDDemo/providers/Microsoft.Storage/storageAccounts/contosostorageaccount
+#This is an optional parameter if you are creating managed disk in the same subscription
+$storageAccountId = '/subscriptions/yourSubscriptionId/resourceGroups/yourResourceGroupName/providers/Microsoft.Storage/storageAccounts/yourStorageAccountName'
+
+#Set the context to the subscription Id where Managed Disk will be created
+Select-AzureRmSubscription -SubscriptionId $SubscriptionId
+
+$diskConfig = New-AzureRmDiskConfig -AccountType $storageType -Location $location -CreateOption Import -StorageAccountId $storageAccountId -SourceUri $sourceVHDURI
+ 
+New-AzureRmDisk -Disk $diskConfig -ResourceGroupName $resourceGroupName -DiskName $diskName
+ 

--- a/virtual-machine/create-snapshots-from-vhd-in-different-subscription/create-snapshots-from-vhd-in-different-subscription.ps1
+++ b/virtual-machine/create-snapshots-from-vhd-in-different-subscription/create-snapshots-from-vhd-in-different-subscription.ps1
@@ -1,0 +1,35 @@
+#Provide the subscription Id where snapshot will be created
+$subscriptionId = 'yourSubscriptionId'
+
+#Provide the name of your resource group where snapshot will be created. 
+$resourceGroupName ='yourResourceGroupName'
+
+#Provide the name of the snapshot
+$snapshotName = 'yourSnapshotName'
+
+#Provide the storage type for snapshot. PremiumLRS or StandardLRS.
+$storageType = 'StandardLRS'
+
+#Provide the Azure region (e.g. westus) where snapshot will be located.
+#This location should be same as the storage account location where VHD file is stored 
+#Get all the Azure location using command below:
+#Get-AzureRmLocation
+$location = 'westus'
+
+#Provide the URI of the VHD file (page blob) in a storage account. Please not that this is NOT the SAS URI of the storage container where VHD file is stored. 
+#e.g. https://contosostorageaccount1.blob.core.windows.net/vhds/contosovhd123.vhd
+#Note: VHD file can be deleted as soon as Managed Disk is created.
+$sourceVHDURI = 'https://yourStorageAccountName.blob.core.windows.net/vhds/yourVHDName.vhd'
+
+#Provide the resource Id of the storage account where VHD file is stored. 
+#e.g. /subscriptions/6582b1g7-e212-446b-b509-314e17e1efb0/resourceGroups/MDDemo/providers/Microsoft.Storage/storageAccounts/contosostorageaccount1
+#This is an optional parameter if you are creating snapshot in the same subscription
+$storageAccountId = '/subscriptions/yourSubscriptionId/resourceGroups/yourResourceGroupName/providers/Microsoft.Storage/storageAccounts/yourStorageAccountName'
+
+#Set the context to the subscription Id where Managed Disk will be created
+Select-AzureRmSubscription -SubscriptionId $SubscriptionId
+
+$snapshotConfig = New-AzureRmSnapshotConfig -AccountType $storageType -Location $location -CreateOption Import -StorageAccountId $storageAccountId -SourceUri $sourceVHDURI 
+ 
+New-AzureRmSnapshot -Snapshot $snapshotConfig -ResourceGroupName $resourceGroupName -SnapshotName $snapshotName
+ 


### PR DESCRIPTION
As part of the storage refactor, I copied the following powershell script folders that each contained one script file, from /storage to storage/vm:

- copy-managed-disks-to-same-or-different-subscription
- copy-snapshot-to-same-or-different-subscription
- copy-snapshot-to-storage-account
- create-managed-disk-from-snapshot
- create-managed-disks-from-vhd-in-different-subscription
- create-snapshots-from-vhd-in-different-subscription

@robinsh @cwatson-cat 