### PR TITLE
Remove the backticks after pipeline character

### DIFF
--- a/virtual-machine/create-vm-detailed/create-vm-detailed.ps1
+++ b/virtual-machine/create-vm-detailed/create-vm-detailed.ps1
@@ -3,7 +3,7 @@ $resourceGroup = "myResourceGroup"
 $location = "westeurope"
 $vmName = "myVM"
 
-# Definer user name and blank password
+# Define user name and blank password
 $securePassword = ConvertTo-SecureString ' ' -AsPlainText -Force
 $cred = New-Object System.Management.Automation.PSCredential ("azureuser", $securePassword)
 
@@ -35,9 +35,9 @@ $nic = New-AzureRmNetworkInterface -Name myNic -ResourceGroupName $resourceGroup
   -SubnetId $vnet.Subnets[0].Id -PublicIpAddressId $pip.Id -NetworkSecurityGroupId $nsg.Id
 
 # Create a virtual machine configuration
-$vmConfig = New-AzureRmVMConfig -VMName $vmName -VMSize Standard_D1 | `
-Set-AzureRmVMOperatingSystem -Linux -ComputerName $vmName -Credential $cred -DisablePasswordAuthentication | `
-Set-AzureRmVMSourceImage -PublisherName Canonical -Offer UbuntuServer -Skus 14.04.2-LTS -Version latest | `
+$vmConfig = New-AzureRmVMConfig -VMName $vmName -VMSize Standard_D1 |
+Set-AzureRmVMOperatingSystem -Linux -ComputerName $vmName -Credential $cred -DisablePasswordAuthentication |
+Set-AzureRmVMSourceImage -PublisherName Canonical -Offer UbuntuServer -Skus 14.04.2-LTS -Version latest |
 Add-AzureRmVMNetworkInterface -Id $nic.Id
 
 # Configure SSH Keys


### PR DESCRIPTION
Backticks are not needed after "|".