### PR TITLE
(AzureCXP) Fixes MicrosoftDocs/azure-docs#28907

### DIFF
--- a/app-service/scale-manual/scale-manual.ps1
+++ b/app-service/scale-manual/scale-manual.ps1
@@ -14,7 +14,7 @@ New-AzResourceGroup -Name $ResourceGroupName -Location $Location
 New-AzAppservicePlan -Name AppServiceManualScalePlan -ResourceGroupName $ResourceGroupName -Location $Location -Tier Basic
 
 # Create a Web App in the App Service Plan
-New-AzWebApp -Name $AppName -ResourceGroupName $ResourceGroup -Location $Location -AppServicePlan AppServiceManualScalePlan
+New-AzWebApp -Name $AppName -ResourceGroupName $ResourceGroupName -Location $Location -AppServicePlan AppServiceManualScalePlan
 
 # Scale Web App to 2 Workers
 Set-AzAppServicePlan -NumberofWorkers 2 -Name AppServiceManualScalePlan -ResourceGroupName $ResourceGroupName


### PR DESCRIPTION
Fixes incorrect reference to ResourceGroupName parameter while creating a Web App in the App Service Plan.