### PR TITLE
fix for priority change script for Cosmos DB

### DIFF
--- a/cosmosdb/common/ps-account-failover-priority-update.ps1
+++ b/cosmosdb/common/ps-account-failover-priority-update.ps1
@@ -1,15 +1,17 @@
 # Change the failover priority for an Azure Cosmos Account
 # Assume West US = 0 and East US = 1, the script below will flip them
 # Updating location with failoverPriority = 0 will trigger a failover
-$resourceGroupName = "myResourceGroup"
-$accountName = "mycosmosaccount"
 $resourceType = "Microsoft.DocumentDb/databaseAccounts"
 $apiVersion = "2015-04-08"
 
-$failoverPolicies = @(
+$failoverRegions = @(
     @{ "locationName"="East US"; "failoverPriority"=0 },
     @{ "locationName"="West US"; "failoverPriority"=1 }
 )
+
+$failoverPolicies = @{ 
+    "failoverPolicies"= $failoverRegions
+}
 
 Invoke-AzResourceAction -Action failoverPriorityChange `
     -ResourceType $resourceType -ApiVersion $apiVersion `

--- a/cosmosdb/common/ps-account-failover-priority-update.ps1
+++ b/cosmosdb/common/ps-account-failover-priority-update.ps1
@@ -1,6 +1,8 @@
 # Change the failover priority for an Azure Cosmos Account
 # Assume West US = 0 and East US = 1, the script below will flip them
 # Updating location with failoverPriority = 0 will trigger a failover
+$resourceGroupName = "myResourceGroup"
+$accountName = "mycosmosaccount"
 $resourceType = "Microsoft.DocumentDb/databaseAccounts"
 $apiVersion = "2015-04-08"
 

--- a/cosmosdb/common/ps-account-failover-priority-update.ps1
+++ b/cosmosdb/common/ps-account-failover-priority-update.ps1
@@ -1,10 +1,29 @@
 # Change the failover priority for a single-master Azure Cosmos Account
-# Assume West US 2 = 0 and East US 2 = 1, the script below will flip them
 # Note: Updating location with failoverPriority = 0 triggers a failover to the new region
+
+$location = "West US 2"
 $resourceGroupName = "myResourceGroup"
-$accountName = "mycosmosaccount"
+$accountName = "mycosmosaccount" # must be lower case.
 $resourceType = "Microsoft.DocumentDb/databaseAccounts"
 $apiVersion = "2015-04-08"
+
+# Provision a new Cosmos account with the regions below
+$locations = @(
+    @{ "locationName"="West US 2"; "failoverPriority"=0 },
+    @{ "locationName"="East US 2"; "failoverPriority"=1 }
+)
+
+$CosmosDBProperties = @{
+    "databaseAccountOfferType"="Standard";
+    "locations"=$locations
+}
+
+New-AzResource -ResourceType $resourceType `
+    -ApiVersion $apiVersion -ResourceGroupName $resourceGroupName -Location $location `
+    -Name $accountName -PropertyObject $CosmosDBProperties
+
+# Change the failover priority. Updating write region which will trigger a failover
+Read-Host -Prompt "Press any key to change the failover priority"
 
 $failoverRegions = @(
     @{ "locationName"="East US 2"; "failoverPriority"=0 },

--- a/cosmosdb/common/ps-account-failover-priority-update.ps1
+++ b/cosmosdb/common/ps-account-failover-priority-update.ps1
@@ -3,6 +3,8 @@
 # Updating location with failoverPriority = 0 will trigger a failover
 $resourceGroupName = "myResourceGroup"
 $accountName = "mycosmosaccount"
+$resourceType = "Microsoft.DocumentDb/databaseAccounts"
+$apiVersion = "2015-04-08"
 
 $failoverPolicies = @(
     @{ "locationName"="East US"; "failoverPriority"=0 },
@@ -10,5 +12,5 @@ $failoverPolicies = @(
 )
 
 Invoke-AzResourceAction -Action failoverPriorityChange `
-    -ResourceType "Microsoft.DocumentDb/databaseAccounts" -ApiVersion "2015-04-08" `
+    -ResourceType $resourceType -ApiVersion $apiVersion `
     -ResourceGroupName $resourceGroupName -Name $accountName -Parameters $failoverPolicies

--- a/cosmosdb/common/ps-account-failover-priority-update.ps1
+++ b/cosmosdb/common/ps-account-failover-priority-update.ps1
@@ -1,14 +1,14 @@
-# Change the failover priority for an Azure Cosmos Account
-# Assume West US = 0 and East US = 1, the script below will flip them
-# Updating location with failoverPriority = 0 will trigger a failover
+# Change the failover priority for a single-master Azure Cosmos Account
+# Assume West US 2 = 0 and East US 2 = 1, the script below will flip them
+# Note: Updating location with failoverPriority = 0 triggers a failover to the new region
 $resourceGroupName = "myResourceGroup"
 $accountName = "mycosmosaccount"
 $resourceType = "Microsoft.DocumentDb/databaseAccounts"
 $apiVersion = "2015-04-08"
 
 $failoverRegions = @(
-    @{ "locationName"="East US"; "failoverPriority"=0 },
-    @{ "locationName"="West US"; "failoverPriority"=1 }
+    @{ "locationName"="East US 2"; "failoverPriority"=0 },
+    @{ "locationName"="West US 2"; "failoverPriority"=1 }
 )
 
 $failoverPolicies = @{ 


### PR DESCRIPTION
## Description

small fix for failover priority change for Cosmos DB

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    Checkboxes in the REQUIRED section must be green. Even if you are only updating
    an existing script, you must follow the REQUIRED steps. Checkboxes in OPTIONAL
    should only be checked if they apply to this PR/your service.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

### Required

- [ ] This pull request was tested on __both of__:
  - [ ] PowerShell 5.1 (Windows)
  - [ ] The latest non-preview Powershell. ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
    - __PowerShell version__ (`$PSVersionTable.PSVersion`):
- [x] This pull request was tested with the latest version of the `Az` module. ([Latest version](https://docs.microsoft.com/powershell/azure/release-notes-azureps))
  - __Az module version__ (`(Get-InstalledModule -Name Az).Version`): 
- [x] The scripts in this pull request use only `Az` commands.
  - [x] I have an exemption (explained in the __Optional__ section)
- [x] Scripts do not contain static passwords or other secret tokens.
  - [x] New passwords are automatically generated (by `New-Guid` or another secure RNG method)
  - [x] Existing secrets are user-supplied
- [x] All prerequisite resources are listed in comments at the top of the scripts.
- [x] All required imports are at the top of scripts, below prerequisites.
- [x] All user-set variables are at the top of scripts, below imports.
- [ ] All identifiers which must be universally unique are guaranteed to be so.
- [x] All scripts use UNIX-style line endings (LF) ([Instructions](https://help.github.com/articles/dealing-with-line-endings))

### Optional

- [ ] User-set variables have initial values guaranteed to cause the script to fail.  
- [ ] This PR requires AzureRM because:
  - [ ] Scripts use a preview module only available for AzureRM
    - __List of preview modules and versions__:
  - [ ] Scripts use service(s) not fully supported in Az
    - __List of services__:
  - [ ] Touches services which have an exemption from the Az requirement
    - __List of services__:
  - [ ] Scripts use the classic deployment model
  - [ ] Scripts use Azure Stack
  - [ ] Other (please explain):

