### PR TITLE
Normesta azcopy fixes

### DIFF
--- a/storage/migrate-blobs-between-accounts/migrate-blobs-between-accounts.ps1
+++ b/storage/migrate-blobs-between-accounts/migrate-blobs-between-accounts.ps1
@@ -99,7 +99,7 @@ elseif((Get-Item $AzCopyPath).BaseName -eq "AzCopy")
     $FileItemVersion = (Get-Item $AzCopyPath).VersionInfo
     $FilePath = ("{0}.{1}.{2}.{3}" -f  $FileItemVersion.FileMajorPart,  $FileItemVersion.FileMinorPart,  $FileItemVersion.FileBuildPart,  $FileItemVersion.FilePrivatePart)
 
-    if([version] $FilePath -lt "7.0.0.2")
+    if(([version] $FilePath -lt "7.0.0.2") -and ([version] $FilePath -ne "0.0.0.0")) 
     {
         $AzCopyPath = Read-Host "Version of AzCopy found at provided path is of a lower, unsupported version. Please input the full filePath of the AzCopy.exe that is version 7.0.0.2 or higher, e.g.: C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
     }
@@ -159,7 +159,7 @@ do{
 
         # Get AzCopy command for transfer one container
         $destContainer = $destCtx.StorageAccount.CreateCloudBlobClient().GetContainerReference($container.Name)
-        $azCopyCmd = [string]::Format("""{0}"" /source:{1} /dest:{2} /sourcekey:""{3}"" /destkey:""{4}"" /snapshot /y /s /synccopy",$AzCopyPath, $container.CloudBlobContainer.Uri.AbsoluteUri, $destContainer.Uri.AbsoluteUri, $srcStorageAccountKey, $DestStorageAccountKey)
+        $azCopyCmd = [string]::Format("""{0}"" /source:{1} /dest:{2} /sourcekey:""{3}"" /destkey:""{4}"" /snapshot /y /s /synccopy",$AzCopyPath, $container.CloudBlobContainer.Uri.AbsoluteUri, [System.String]::Format("{0}/{1}", $destCtx.BlobEndPoint.TrimEnd('/'), $container.Name), $srcStorageAccountKey, $DestStorageAccountKey)
     
         # Execute the AzCopy command first time
         Write-Host "$azCopyCmd"

--- a/storage/migrate-blobs-between-accounts/migrate-blobs-between-accounts.ps1
+++ b/storage/migrate-blobs-between-accounts/migrate-blobs-between-accounts.ps1
@@ -158,7 +158,6 @@ do{
         $retry = 1
 
         # Get AzCopy command for transfer one container
-        $destContainer = $destCtx.StorageAccount.CreateCloudBlobClient().GetContainerReference($container.Name)
         $azCopyCmd = [string]::Format("""{0}"" /source:{1} /dest:{2} /sourcekey:""{3}"" /destkey:""{4}"" /snapshot /y /s /synccopy",$AzCopyPath, $container.CloudBlobContainer.Uri.AbsoluteUri, [System.String]::Format("{0}/{1}", $destCtx.BlobEndPoint.TrimEnd('/'), $container.Name), $srcStorageAccountKey, $DestStorageAccountKey)
     
         # Execute the AzCopy command first time


### PR DESCRIPTION
## Description

<!-- Please include a brief description of your changes. -->

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    Checkboxes in the REQUIRED section must be green. Even if you are only updating
    an existing script, you must follow the REQUIRED steps. Checkboxes in OPTIONAL
    should only be checked if they apply to this PR/your service.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

### Required

- [ ] This pull request was tested on __both of__:
  - [X] PowerShell 5.1 (Windows)
  - [ ] The latest non-preview Powershell. ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
    - __PowerShell version__ (`$PSVersionTable.PSVersion`):
- [X] This pull request was tested with the latest version of the `Az` module. ([Latest version](https://docs.microsoft.com/powershell/azure/release-notes-azureps))
  - __Az module version__ (`(Get-InstalledModule -Name Az).Version`): 
- [X] The scripts in this pull request use only `Az` commands.
  - [ ] I have an exemption (explained in the __Optional__ section)
- [X] Scripts do not contain static passwords or other secret tokens.
  - [ ] New passwords are automatically generated (by `New-Guid` or another secure RNG method)
  - [ ] Existing secrets are user-supplied
- [X] All prerequisite resources are listed in comments at the top of the scripts.
- [X] All required imports are at the top of scripts, below prerequisites.
- [X] All user-set variables are at the top of scripts, below imports.
- [X] All identifiers which must be universally unique are guaranteed to be so.
- [X] All scripts use UNIX-style line endings (LF) ([Instructions](https://help.github.com/articles/dealing-with-line-endings))

### Optional

- [ ] User-set variables have initial values guaranteed to cause the script to fail.  
- [ ] This PR requires AzureRM because:
  - [ ] Scripts use a preview module only available for AzureRM
    - __List of preview modules and versions__:
  - [ ] Scripts use service(s) not fully supported in Az
    - __List of services__:
  - [ ] Touches services which have an exemption from the Az requirement
    - __List of services__:
  - [ ] Scripts use the classic deployment model
  - [ ] Scripts use Azure Stack
  - [ ] Other (please explain):

