### PR TITLE
fix incorrect variable names

### DIFF
--- a/sql-database/move-database-between-pools-and-standalone/move-database-between-pools-and-standalone.ps1
+++ b/sql-database/move-database-between-pools-and-standalone/move-database-between-pools-and-standalone.ps1
@@ -1,5 +1,5 @@
 # Connect-AzAccount
-$SubscriptionId = ''
+$SubscriptionId = '<replace with your subscription id>'
 # Set the resource group name and location for your server
 $resourceGroupName = "myResourceGroup-$(Get-Random)"
 $location = "westus2"
@@ -8,7 +8,7 @@ $firstPoolName = "MyFirstPool"
 $secondPoolName = "MySecondPool"
 # Set an admin login and password for your server
 $adminSqlLogin = "SqlAdmin"
-$password = "ChangeYourAdminPassword1"
+$password = "<EnterYourComplexPasswordHere>"
 # The logical server name has to be unique in the system
 $serverName = "server-$(Get-Random)"
 # The sample database names
@@ -58,8 +58,8 @@ $firstDatabase = New-AzSqlDatabase  -ResourceGroupName $resourceGroupName `
     -ElasticPoolName $firstPoolName
 $secondDatabase = New-AzSqlDatabase  -ResourceGroupName $resourceGroupName `
     -ServerName $serverName `
-    -DatabaseName "MySecondSampleDatabase" `
-    -ElasticPoolName "MySecondPool"
+    -DatabaseName $secondDatabaseName `
+    -ElasticPoolName $secondPoolName
 
 # Move the database to the second pool
 $firstDatabase = Set-AzSqlDatabase -ResourceGroupName $resourceGroupName `

--- a/sql-database/move-database-between-pools-and-standalone/move-database-between-pools-and-standalone.ps1
+++ b/sql-database/move-database-between-pools-and-standalone/move-database-between-pools-and-standalone.ps1
@@ -3,7 +3,7 @@ $SubscriptionId = '<replace with your subscription id>'
 # Set the resource group name and location for your server
 $resourceGroupName = "myResourceGroup-$(Get-Random)"
 $location = "westus2"
-# Set elastic poool names
+# Set elastic pool names
 $firstPoolName = "MyFirstPool"
 $secondPoolName = "MySecondPool"
 # Set an admin login and password for your server


### PR DESCRIPTION
## Description

Fixed incorrect parameter names, and clarified a couple placeholders.
This is existing content and I'm simply fixing a user raised issue regarding the incorrect variable names. 

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    Checkboxes in the REQUIRED section must be green. Even if you are only updating
    an existing script, you must follow the REQUIRED steps. Checkboxes in OPTIONAL
    should only be checked if they apply to this PR/your service.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

### Required

- [X] This pull request was tested on __both of__:
  - [X] PowerShell 5.1 (Windows)
  - [X] The latest non-preview Powershell. ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
    - __PowerShell version__ (`$PSVersionTable.PSVersion`):
- [X] This pull request was tested with the latest version of the `Az` module. ([Latest version](https://docs.microsoft.com/powershell/azure/release-notes-azureps))
  - __Az module version__ (`(Get-InstalledModule -Name Az).Version`): 
- [X] The scripts in this pull request use only `Az` commands.
  - [ ] I have an exemption (explained in the __Optional__ section)
- [X] Scripts do not contain static passwords or other secret tokens.
  - [ ] New passwords are automatically generated (by `New-Guid` or another secure RNG method)
  - [X] Existing secrets are user-supplied
- [X] All prerequisite resources are listed in comments at the top of the scripts.
- [X] All required imports are at the top of scripts, below prerequisites.
- [X] All user-set variables are at the top of scripts, below imports.
- [X] All identifiers which must be universally unique are guaranteed to be so.
- [X] All scripts use UNIX-style line endings (LF) ([Instructions](https://help.github.com/articles/dealing-with-line-endings))

### Optional

- [ ] User-set variables have initial values guaranteed to cause the script to fail.  
- [ ] This PR requires AzureRM because:
  - [ ] Scripts use a preview module only available for AzureRM
    - __List of preview modules and versions__:
  - [ ] Scripts use service(s) not fully supported in Az
    - __List of services__:
  - [ ] Touches services which have an exemption from the Az requirement
    - __List of services__:
  - [ ] Scripts use the classic deployment model
  - [ ] Scripts use Azure Stack
  - [ ] Other (please explain):

