### PR TITLE
Fix typos in create-managed-disks-from-vhd-in-different-subscription/…

### DIFF
--- a/virtual-machine/create-managed-disks-from-vhd-in-different-subscription/create-managed-disks-from-vhd-in-different-subscription.ps1
+++ b/virtual-machine/create-managed-disks-from-vhd-in-different-subscription/create-managed-disks-from-vhd-in-different-subscription.ps1
@@ -33,6 +33,5 @@ $storageAccountId = '/subscriptions/yourSubscriptionId/resourceGroups/yourResour
 Select-AzSubscription -SubscriptionId $SubscriptionId
 
 $diskConfig = New-AzDiskConfig -AccountType $storageType -Location $location -CreateOption Import -StorageAccountId $storageAccountId -SourceUri $sourceVHDURI
-Â 
+
 New-AzDisk -Disk $diskConfig -ResourceGroupName $resourceGroupName -DiskName $diskName
-Â 


### PR DESCRIPTION
…create-managed-disks-from-vhd-in-different-subscription.ps1

## Description

Fix stray characters in create-managed-disks-from-vhd-in-different-subscription/create-managed-disks-from-vhd-in-different-subscription.ps1

## Checklist

- [X] This pull request was tested on __both of__:
  - [X] PowerShell 5.1 (Windows)
  - [X] PowerShell 6.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [X] Scripts do not contain static passwords or other secret tokens.
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

Platform:

Powershell version: `$PSVersionTable.PSVersion`

Az version: `(Get-InstalledModule -Name Az).Version`
