### PR TITLE
Fixing bug and adding registration to the RP

### DIFF
--- a/sql-virtual-machine/register-sql-vms/RegisterSqlVMs.psm1
+++ b/sql-virtual-machine/register-sql-vms/RegisterSqlVMs.psm1
@@ -9,12 +9,12 @@
     Register all Azure VM running SQL Server on Windows with SQL VM Resource provider.
 
     .DESCRIPTION
-    Identify and register all Azure VM running SQL Server on Windows in a list of subscriptions, resource group list, particular resourcegroup
+    Identify and register all Azure VM running SQL Server on Windows in a list of subscriptions, resource group list, particular resource group
     or a particular VM with SQL VM Resource provider.
     The cmdlet registers the VMs and generates a report and a log file at the end of the execution. The report is generated as a txt file named
     RegisterSqlVMScriptReport<Timestamp>.txt. Errors are logged in the log file named VMsNotRegisteredDueToError<Timestamp>.log. Timestamp is the
     time when the cmdlet was started. A summary is displayed at the end of the script run.
-    The Output summary contains the number of VMs that successfuly registered, failed or were skipped because of various reasons. The detailed list
+    The Output summary contains the number of VMs that successfully registered, failed or were skipped because of various reasons. The detailed list
     of VMs can be found in the report and the details of error can be found in the log.
 
     Prerequisites:
@@ -239,7 +239,7 @@ function Register-SqlVMs {
     new-Report
 }
 
-#Globals for reporting and loging
+#Globals for reporting and logging
 $Global:TotalVMs = 0
 $Global:AlreadyRegistered = 0
 $Global:SubscriptionsFailedToRegister = 0
@@ -529,7 +529,7 @@ function Get-DisclaimerAcceptance() {
 
 <#
     .SYNOPSIS
-    Creates a new line dashed seperator
+    Creates a new line dashed separator
 #>
 function new-DashSeperator() {
     Write-Host
@@ -731,7 +731,7 @@ function assert-Subscription(
     Name of the resourceGroup which needs to be searched for VMs
 
     .PARAMETER Name
-    Name of the VM which is to be registerd
+    Name of the VM which is to be registered
 #>
 function register-SqlVMForSubscription (
     [Parameter(Mandatory = $true)]

--- a/sql-virtual-machine/register-sql-vms/RegisterSqlVMs.psm1
+++ b/sql-virtual-machine/register-sql-vms/RegisterSqlVMs.psm1
@@ -26,7 +26,9 @@
       Contributor or Owner
     - The script requires Az powershell module (>=2.8.0) to be installed. Details on how to install Az module can be found 
       here : https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-2.8.0
-      It specifically requires Az.Compute, Az.Accounts, Az.SqlVirtualMachine and Az.Resources module which comes as part of Az module (>=2.8.0) installation.
+      It specifically requires Az.Compute, Az.Accounts and Az.Resources module which comes as part of Az module (>=2.8.0) installation.
+    - The script also requires Az.SqlVirtualMachine module. Details on how to install Az.SqlVirtualMachine can be
+      found here: https://www.powershellgallery.com/packages/Az.SqlVirtualMachine/0.1.0
 
     .PARAMETER SubscriptionList
     List of Subscriptions whose VMs need to be registered

--- a/sql-virtual-machine/register-sql-vms/RegisterSqlVMs.psm1
+++ b/sql-virtual-machine/register-sql-vms/RegisterSqlVMs.psm1
@@ -20,12 +20,12 @@
     Prerequisites:
     - The script needs to be run on Powershell 5.1 (Windows Only) and is incompatible with Powershell 6.x
     - The subscription whose VMs are to be registered, needs to be registered to Microsoft.SqlVirtualMachine resource provider first. This link describes
-      how to register to a resource provider: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-supported-services
+      how to register to a resource provider: https://docs.microsoft.com/azure/azure-resource-manager/resource-manager-supported-services
     - Run 'Connect-AzAccount' to first connect the powershell session to the azure account.
     - The Client credentials must have one of the following RBAC levels of access over the virtual machine being registered: Virtual Machine Contributor,
       Contributor or Owner
     - The script requires Az powershell module (>=2.8.0) to be installed. Details on how to install Az module can be found 
-      here : https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-2.8.0
+      here : https://docs.microsoft.com/powershell/azure/install-az-ps?view=azps-2.8.0
       It specifically requires Az.Compute, Az.Accounts and Az.Resources module which comes as part of Az module (>=2.8.0) installation.
     - The script also requires Az.SqlVirtualMachine module. Details on how to install Az.SqlVirtualMachine can be
       found here: https://www.powershellgallery.com/packages/Az.SqlVirtualMachine/0.1.0
@@ -705,10 +705,10 @@ function assert-Subscription(
         # try register subscription to the SqlVirtualMachine
         $register = Register-AzResourceProvider -ProviderNamespace Microsoft.SqlVirtualMachine -ErrorAction SilentlyContinue
         if ((!$register) -or ($register.RegistrationState -ne 'Registering')) {
-            $errorMessage = "$($Subscription), Subscription $($Subscription) should be registered to 'Microsoft.SqlVirtualMachine'. Steps to register can be found here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-supported-services. This registration may take around 5 mins to propogate."
+            $errorMessage = "$($Subscription), Subscription $($Subscription) should be registered to 'Microsoft.SqlVirtualMachine'. Steps to register can be found here: https://docs.microsoft.com/azure/azure-resource-manager/resource-manager-supported-services. This registration may take around 5 mins to propagate."
         }
         else {
-            $errorMessage = "$($Subscription), Subscription $($Subscription) is registering to 'Microsoft.SqlVirtualMachine'. This registration may take around 5 mins to propogate. Run the script again for this subscription."
+            $errorMessage = "$($Subscription), Subscription $($Subscription) is registering to 'Microsoft.SqlVirtualMachine'. This registration may take around 5 mins to propagate. Run the script again for this subscription."
         }
         Write-Output $errorMessage | Out-File $Global:LogFile -Append
         $tmp = $Global:SubscriptionsFailedToRegister.Add($Subscription)


### PR DESCRIPTION
<!--
    Thanks for contributing to the Azure PowerShell samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - PowerShell style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-ps?branch=master 
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description
The change is to resolve following issues:
- We should avoid registering in Full Mode. Due to a bug in the RP the error saying that the VM was already in full mode may not be true. So it is not worth the risk
- We should Run the script to register subscription to sql virtual machine and log it accordingly
- There was a bug in the script which led to script failing if there is only one VM in a Resource Group or subscription. When Get-AzVM returns a single value, typecasting to array does not work.
- There was a bug when writing to log file during subscription related errors overwrote the log file.

<!-- Include a brief description of your changes. -->

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [ ] This pull request was tested on __both of__:
  - [X] PowerShell 5.1 (Windows)
  - [ ] PowerShell 6.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [X] Scripts do not contain static passwords or other secret tokens.
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

<!--
    Each testing environment is a triplet:

        Platform, PowerShell version, Az version

    Copy/paste and fill in the following block for as many combinations of the above as you tested on.
-->

Platform:
windows 10
powershell 5 1 18362 145
az 2 8 0 -1

Incompatible with powershell core 6.1 as mentioned in the script prerequisites