### PR TITLE
Cosmos DB | Add resource lock samples

### DIFF
--- a/cosmosdb/cassandra/ps-cassandra-lock.ps1
+++ b/cosmosdb/cassandra/ps-cassandra-lock.ps1
@@ -1,0 +1,79 @@
+# References:
+# Az.CosmosDB | https://docs.microsoft.com/powershell/module/az.cosmosdb
+# Az.Resources | https://docs.microsoft.com/powershell/module/az.resources
+# --------------------------------------------------
+# Purpose
+# 
+# --------------------------------------------------
+# Variables
+# ***** SUBSTITUTE YOUR VALUES *****
+$resourceGroupName = "myResourceGroup"
+$accountName = "myaccount"
+$databaseName = "mykeyspace"
+$collectionName = "mytable"
+# *****
+$apiVersion = "2020-04-01" # Cosmos DB RP API version
+$lockLevel = "CanNotDelete" # CanNotDelete or ReadOnly
+
+$resourceTypeAccount = "Microsoft.DocumentDB/databaseAccounts"
+$resourceTypeDatabase = "$resourceTypeAccount/cassandraKeyspaces"
+$resourceTypeCollection = "$resourceTypeDatabase/tables"
+
+$resourceNameDatabase = "$accountName/$databaseName"
+$lockNameDatabase = "$accountName-$databaseName-Lock"
+
+$resourceNameCollection = "$accountName/$databaseName/$collectionName"
+$lockNameCollection = "$accountName-$databaseName-$collectionName-Lock"
+# --------------------------------------------------
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameDatabase"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameCollection"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "List all locks on  Cosmos DB account $accountName to confirm lock creation"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName
+
+Write-Host "Delete lock on resource $resourceNameDatabase"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-Force
+
+Write-Host "Delete lock on resource $resourceNameCollection"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-Force
+
+Write-Host "List all locks on Cosmos DB account $accountName to confirm lock removal"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName

--- a/cosmosdb/gremlin/ps-gremlin-lock.ps1
+++ b/cosmosdb/gremlin/ps-gremlin-lock.ps1
@@ -1,0 +1,79 @@
+# References:
+# Az.CosmosDB | https://docs.microsoft.com/powershell/module/az.cosmosdb
+# Az.Resources | https://docs.microsoft.com/powershell/module/az.resources
+# --------------------------------------------------
+# Purpose
+# 
+# --------------------------------------------------
+# Variables
+# ***** SUBSTITUTE YOUR VALUES *****
+$resourceGroupName = "myResourceGroup"
+$accountName = "myaccount"
+$databaseName = "myDatabase"
+$collectionName = "myGraph"
+# *****
+$apiVersion = "2020-04-01" # Cosmos DB RP API version
+$lockLevel = "CanNotDelete" # CanNotDelete or ReadOnly
+
+$resourceTypeAccount = "Microsoft.DocumentDB/databaseAccounts"
+$resourceTypeDatabase = "$resourceTypeAccount/gremlinDatabases"
+$resourceTypeCollection = "$resourceTypeDatabase/graphs"
+
+$resourceNameDatabase = "$accountName/$databaseName"
+$lockNameDatabase = "$accountName-$databaseName-Lock"
+
+$resourceNameCollection = "$accountName/$databaseName/$collectionName"
+$lockNameCollection = "$accountName-$databaseName-$collectionName-Lock"
+# --------------------------------------------------
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameDatabase"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameCollection"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "List all locks on  Cosmos DB account $accountName to confirm lock creation"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName
+
+Write-Host "Delete lock on resource $resourceNameDatabase"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-Force
+
+Write-Host "Delete lock on resource $resourceNameCollection"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-Force
+
+Write-Host "List all locks on Cosmos DB account $accountName to confirm lock removal"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName

--- a/cosmosdb/mongodb/ps-mongodb-lock.ps1
+++ b/cosmosdb/mongodb/ps-mongodb-lock.ps1
@@ -1,0 +1,79 @@
+# References:
+# Az.CosmosDB | https://docs.microsoft.com/powershell/module/az.cosmosdb
+# Az.Resources | https://docs.microsoft.com/powershell/module/az.resources
+# --------------------------------------------------
+# Purpose
+# 
+# --------------------------------------------------
+# Variables
+# ***** SUBSTITUTE YOUR VALUES *****
+$resourceGroupName = "myResourceGroup"
+$accountName = "myaccount"
+$databaseName = "myDatabase"
+$collectionName = "myCollection"
+# *****
+$apiVersion = "2020-04-01" # Cosmos DB RP API version
+$lockLevel = "CanNotDelete" # CanNotDelete or ReadOnly
+
+$resourceTypeAccount = "Microsoft.DocumentDB/databaseAccounts"
+$resourceTypeDatabase = "$resourceTypeAccount/mongodbDatabases"
+$resourceTypeCollection = "$resourceTypeDatabase/collections"
+
+$resourceNameDatabase = "$accountName/$databaseName"
+$lockNameDatabase = "$accountName-$databaseName-Lock"
+
+$resourceNameCollection = "$accountName/$databaseName/$collectionName"
+$lockNameCollection = "$accountName-$databaseName-$collectionName-Lock"
+# --------------------------------------------------
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameDatabase"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameCollection"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "List all locks on  Cosmos DB account $accountName to confirm lock creation"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName
+
+Write-Host "Delete lock on resource $resourceNameDatabase"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-Force
+
+Write-Host "Delete lock on resource $resourceNameCollection"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-Force
+
+Write-Host "List all locks on Cosmos DB account $accountName to confirm lock removal"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName

--- a/cosmosdb/sql/ps-sql-lock.ps1
+++ b/cosmosdb/sql/ps-sql-lock.ps1
@@ -1,0 +1,79 @@
+# References:
+# Az.CosmosDB | https://docs.microsoft.com/powershell/module/az.cosmosdb
+# Az.Resources | https://docs.microsoft.com/powershell/module/az.resources
+# --------------------------------------------------
+# Purpose
+# 
+# --------------------------------------------------
+# Variables
+# ***** SUBSTITUTE YOUR VALUES *****
+$resourceGroupName = "myResourceGroup"
+$accountName = "myaccount"
+$databaseName = "myDatabase"
+$collectionName = "myContainer"
+# *****
+$apiVersion = "2020-04-01" # Cosmos DB RP API version
+$lockLevel = "CanNotDelete" # CanNotDelete or ReadOnly
+
+$resourceTypeAccount = "Microsoft.DocumentDB/databaseAccounts"
+$resourceTypeDatabase = "$resourceTypeAccount/sqlDatabases"
+$resourceTypeCollection = "$resourceTypeDatabase/containers"
+
+$resourceNameDatabase = "$accountName/$databaseName"
+$lockNameDatabase = "$accountName-$databaseName-Lock"
+
+$resourceNameCollection = "$accountName/$databaseName/$collectionName"
+$lockNameCollection = "$accountName-$databaseName-$collectionName-Lock"
+# --------------------------------------------------
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameDatabase"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameCollection"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "List all locks on  Cosmos DB account $accountName to confirm lock creation"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName
+
+Write-Host "Delete lock on resource $resourceNameDatabase"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-Force
+
+Write-Host "Delete lock on resource $resourceNameCollection"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeCollection `
+	-ResourceName $resourceNameCollection `
+	-LockName $lockNameCollection `
+	-Force
+
+Write-Host "List all locks on Cosmos DB account $accountName to confirm lock removal"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName

--- a/cosmosdb/table/ps-table-lock.ps1
+++ b/cosmosdb/table/ps-table-lock.ps1
@@ -1,0 +1,55 @@
+# References:
+# Az.CosmosDB | https://docs.microsoft.com/powershell/module/az.cosmosdb
+# Az.Resources | https://docs.microsoft.com/powershell/module/az.resources
+# --------------------------------------------------
+# Purpose
+# 
+# --------------------------------------------------
+# Variables
+# ***** SUBSTITUTE YOUR VALUES *****
+$resourceGroupName = "myResourceGroup"
+$accountName = "myaccount"
+$databaseName = "myDatabase"
+# *****
+$apiVersion = "2020-04-01" # Cosmos DB RP API version
+$lockLevel = "CanNotDelete" # CanNotDelete or ReadOnly
+
+$resourceTypeAccount = "Microsoft.DocumentDB/databaseAccounts"
+$resourceTypeDatabase = "$resourceTypeAccount/tables"
+
+$resourceNameDatabase = "$accountName/$databaseName"
+$lockNameDatabase = "$accountName-$databaseName-Lock"
+# --------------------------------------------------
+
+Write-Host "Create a $lockLevel lock on resource $resourceNameDatabase"
+New-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-LockLevel $lockLevel `
+	-Force
+
+Write-Host "List all locks on  Cosmos DB account $accountName to confirm lock creation"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName
+
+Write-Host "Delete lock on resource $resourceNameDatabase"
+Remove-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeDatabase `
+	-ResourceName $resourceNameDatabase `
+	-LockName $lockNameDatabase `
+	-Force
+
+Write-Host "List all locks on Cosmos DB account $accountName to confirm lock removal"
+Get-AzResourceLock `
+	-ApiVersion $apiVersion `
+	-ResourceGroupName $resourceGroupName `
+	-ResourceType $resourceTypeAccount `
+	-ResourceName $accountName


### PR DESCRIPTION

## Description

For each Cosmos DB API add a Powershell script to show creation, listing, and removal of Azure resource locks at the database (parent) and collection (child) level.

## Checklist

- [X] This pull request was tested on __both of__:
  - [X] PowerShell 5.1 (Windows)
  - [ ] PowerShell 6.x
  - [X] PowerShell 7.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [X] Scripts do not contain static passwords or other secret tokens.
- [X] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

Microsoft Windows 10.0.19041, 5.1, 4.2.0
Microsoft Windows 10.0.19041, 7.0.1, 4.2.0
Microsoft Windows 10.0.19041, 7.0.2, 4.2.0