### PR TITLE
fix spelling

### DIFF
--- a/storage/post-storage-logs-to-log-analytics/PostStorageLogs2LogAnalytics.ps1
+++ b/storage/post-storage-logs-to-log-analytics/PostStorageLogs2LogAnalytics.ps1
@@ -269,7 +269,7 @@ $containers | ForEach-Object {
             $filename = ".\log.txt"
             Get-AzStorageBlobContent -Context $storageContext -Container $container.Name -Blob $blob.Name -Destination $filename -Force > Null
             
-            Write-Output("> Posting logs to log analytic worspace: {0}" -f $blob.Name)
+            Write-Output("> Posting logs to log analytic workspace: {0}" -f $blob.Name)
             $lines = Get-Content $filename
 
             # Enumerate log lines in each log blob


### PR DESCRIPTION
## Description

Spelling mistake in a powershell script

## Checklist

No tests required as it is just fixing some text

Platform and PowerShell version: `[pscustomobject]$PSVersionTable | Select-Object OS, BuildVersion, PSVersion`

Az version: `(Get-InstalledModule -Name Az).Version`
