### PR TITLE
Update sample import script to use a valid value for MaxSizeBytes

### DIFF
--- a/sql-database/import-from-bacpac/import-from-bacpac.ps1
+++ b/sql-database/import-from-bacpac/import-from-bacpac.ps1
@@ -62,7 +62,7 @@ $serverFirewallRule = New-AzSqlServerFirewallRule -ResourceGroupName $resourceGr
 $importRequest = New-AzSqlDatabaseImport -ResourceGroupName $resourceGroupName `
     -ServerName $serverName `
     -DatabaseName $databaseName `
-    -DatabaseMaxSizeBytes "262144000" `
+    -DatabaseMaxSizeBytes 100GB `
     -StorageKeyType "StorageAccessKey" `
     -StorageKey $(Get-AzStorageAccountKey -ResourceGroupName $resourceGroupName -StorageAccountName $storageAccountName).Value[0] `
     -StorageUri "https://$storageaccountname.blob.core.windows.net/$storageContainerName/$bacpacFilename" `


### PR DESCRIPTION
## Description

The value previously in use (262144000, which is 250MB) is not a valid size for an S3 database. Trying to create a database of that size will throw an error like `The edition 'Standard' does not support the database data max size '262144000'.`

I am not clear whether 250MB was *ever* a valid size for S3, but it certainly is not now. It used to be the case that the Import/Export service would silently swallow this error and just create a database of the max size for the SLO. However, that (buggy) behavior was fixed around November 2020 to respect the parameter.

## Checklist

- [x] This pull request was tested on __both of__:
  - [x] PowerShell 5.1 (Windows)
  - [ ] PowerShell 6.x
  - [ ] PowerShell 7.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [x] Scripts do not contain static passwords or other secret tokens.
- [x] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

Platform and PowerShell version: 10.0.19041.906, 5.1.19041.906

Az version: 5.2.0
