### PR TITLE
Fix V3 Get-AzMigDependenciesAgentless

### DIFF
--- a/azure-migrate/dependencies-at-scale/AzMig_Dependencies.psm1
+++ b/azure-migrate/dependencies-at-scale/AzMig_Dependencies.psm1
@@ -386,12 +386,14 @@ function Get-AzMigDependenciesAgentless {
 			throw "Could not retrieve the site for appliance $appliancename"
     }
 	
-	$sites = ConvertFrom-Json $siteresponse.properties.details.extendedDetails.applianceNameToSiteIdMapV2
+	$sites = ConvertFrom-Json $siteresponse.properties.details.extendedDetails.applianceNameToSiteIdMapV3
 	
 	$VMwareSiteID = ""
 	
 	foreach ($site in $sites) {
 	
+		$site = $site | Select-Object -ExpandProperty *
+		
 		$appliancename = $site.ApplianceName;
 		
 		if ($Appliance -ne $appliancename) {continue}


### PR DESCRIPTION
<!--
    Thanks for contributing to the Azure PowerShell samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - PowerShell style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-ps?branch=master 
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description

Fixes `Get-AzMigDependenciesAgentless` now that API returns `applianceNameToSiteIdMapV3` rather than `applianceNameToSiteIdMapV2`

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [x] This pull request was tested on __both of__:
  - [x] PowerShell 5.1 (Windows)
  - [x] PowerShell 6.x
  - [x] PowerShell 7.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [x] Scripts do not contain static passwords or other secret tokens.
- [x] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

<!--
    Each testing environment is a triplet:

        Platform, PowerShell version, Az version

    Copy/paste and fill in the following block for as many combinations of the above as you tested on.
-->

Platform and PowerShell version: `Darwin 21.1.0 Darwin Kernel Version 21.1.0: Thu Sep 30 06:42:03 PDT 2021; root:xnu-8019.40.96.0.2~12/RELEASE_ARM64_T8101` `7.1.4`
Az version: `6.4.0`