### PR TITLE
Cosmos DB | Fix typo in keyKind values

### DIFF
--- a/cosmosdb/common/ps-account-keys-connection-strings.ps1
+++ b/cosmosdb/common/ps-account-keys-connection-strings.ps1
@@ -6,7 +6,7 @@
 # Variables - ***** SUBSTITUTE YOUR VALUES *****
 $resourceGroupName = "myResourceGroup" # Resource Group must already exist
 $accountName = "myaccount" # Must be all lower case
-$keyKind = "primary" # Other key kinds: secondary, primaryReadOnly, secondaryReadOnly
+$keyKind = "primary" # Other key kinds: secondary, primaryReadonly, secondaryReadonly
 # --------------------------------------------------
 
 Write-Host "List connection strings"


### PR DESCRIPTION
## Description

Per microsoftdocs/azure-docs#94082, the potential values for the ``-KeyKind`` parameter had a casing error. I double-checked the [documentation](https://docs.microsoft.com/powershell/module/az.cosmosdb/new-azcosmosdbaccountkey#parameters), tested, and made a quick change

## Checklist

- [ ] This pull request was tested on __both of__:
  - [ ] PowerShell 5.1 (Windows)
  - [ ] PowerShell 6.x
  - [x] PowerShell 7.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [x] Scripts do not contain static passwords or other secret tokens.
- [x] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

Platform and PowerShell version: `Linux 5.4.0-1083-azure #87~18.04.1-Ubuntu SMP` *(Azure Cloud Shell)*

Az version: `8.0.0`
