### PR TITLE
Update export-apps-with-expiring-secrets.ps1

### DIFF
--- a/application-management/export-apps-with-expiring-secrets.ps1
+++ b/application-management/export-apps-with-expiring-secrets.ps1
@@ -113,6 +113,8 @@ foreach ($app in $Applications) {
 
                 $Log | Add-Member -MemberType NoteProperty -Name "ApplicationName" -Value $AppName
                 $Log | Add-Member -MemberType NoteProperty -Name "ApplicationID" -Value $ApplID
+                $Log | Add-Member -MemberType NoteProperty -Name "Secret Start Date" -Value $null
+                $Log | Add-Member -MemberType NoteProperty -Name "Secret End Date" -value $null
                 $Log | Add-Member -MemberType NoteProperty -Name "Certificate Start Date" -Value $CStartDate
                 $Log | Add-Member -MemberType NoteProperty -Name "Certificate End Date" -value $CEndDate
                 $Log | Add-Member -MemberType NoteProperty -Name "Owner" -Value $Username
@@ -138,6 +140,8 @@ foreach ($app in $Applications) {
 
                 $Log | Add-Member -MemberType NoteProperty -Name "ApplicationName" -Value $AppName
                 $Log | Add-Member -MemberType NoteProperty -Name "ApplicationID" -Value $ApplID
+                $Log | Add-Member -MemberType NoteProperty -Name "Secret Start Date" -Value $null
+                $Log | Add-Member -MemberType NoteProperty -Name "Secret End Date" -value $null
                 $Log | Add-Member -MemberType NoteProperty -Name "Certificate Start Date" -Value $CStartDate
                 $Log | Add-Member -MemberType NoteProperty -Name "Certificate End Date" -value $CEndDate
                 $Log | Add-Member -MemberType NoteProperty -Name "Owner" -Value $Username


### PR DESCRIPTION
Updated to resolve issue if the 1st retrieved application object doesn't have a client secret, `Export-CSV` will not include the **Secret Start Date** and **Secret End Date** columns, due to `Export-CSV` formatting the file based on the properties of the 1st object. This is noted in the [Export-CSV documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.2#notes)

> When you submit multiple objects to Export-CSV, Export-CSV organizes the file based on the properties of the first object that you submit. If the remaining objects do not have one of the specified properties, the property value of that object is null, as represented by two consecutive commas. If the remaining objects have additional properties, those property values are not included in the file.

<!--
    Thanks for contributing to the Azure PowerShell samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - PowerShell style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-ps?branch=master 
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description

<!-- Include a brief description of your changes. -->

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [ ] This pull request was tested on __both of__:
  - [X] PowerShell 5.1 (Windows)
  - [ ] PowerShell 6.x
  - [ ] PowerShell 7.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [X] Scripts do not contain static passwords or other secret tokens.
- [] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

<!--
    Each testing environment is a triplet:

        Platform, PowerShell version, Az version

    Copy/paste and fill in the following block for as many combinations of the above as you tested on.
-->

Platform and PowerShell version: `[pscustomobject]$PSVersionTable | Select-Object OS, BuildVersion, PSVersion`

Az version: `(Get-InstalledModule -Name Az).Version`
