### PR TITLE
Removed overkill calls to Select-Object -ExpandProperty

### DIFF
--- a/application-management/export-apps-with-expiring-secrets.ps1
+++ b/application-management/export-apps-with-expiring-secrets.ps1
@@ -95,8 +95,7 @@ foreach ($App in $Applications) {
             $Username = '<<No Owner>>'
         }
 
-        $RemainingDaysCount = $EndDate - $Now |
-            Select-Object -ExpandProperty Days
+        $RemainingDaysCount = ($EndDate - $Now).Days
 
         if ($IncludeAlreadyExpired -eq 'No') {
             if ($RemainingDaysCount -le $DaysUntilExpiration -and $RemainingDaysCount -ge 0) {
@@ -150,8 +149,7 @@ foreach ($App in $Applications) {
             $Username = '<<No Owner>>'
         }
 
-        $RemainingDaysCount = $EndDate - $Now |
-            Select-Object -ExpandProperty Days
+        $RemainingDaysCount = ($EndDate - $Now).Days
 
         if ($IncludeAlreadyExpired -eq 'No') {
             if ($RemainingDaysCount -le $DaysUntilExpiration -and $RemainingDaysCount -ge 0) {


### PR DESCRIPTION
The script uses the . operator to access properties ($Secret.StartDateTime) except here:

$RemainingDaysCount = $EndDate - $Now |
            Select-Object -ExpandProperty Days

It is simpler to write
$RemainingDaysCount = ($EndDate - $Now).Days

<!--
    Thanks for contributing to the Azure PowerShell samples repo! For contributors, make sure that you
    fill in the PR checklist in this template, and:

    * Internal contributors: Follow the style guides and PR submission process docs:
        - PowerShell style guide: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-ps?branch=master 
        - Best practices: https://review.docs.microsoft.com/en-us/help/contribute/conventions-azure-scripts?branch=master
        - PR submission process: https://review.docs.microsoft.com/en-us/help/contribute/contribute-scripts-pr-process?branch=master

    * External contributors: Make sure that you test _all_ of your scripts that you modified. You can't read the contribution
        guides yet, but reviewer feedback will be detailed and clear about any required changes.
-->

## Description

Simplified and made code cleaner by removing Select-Object -ExpandPropert

## Checklist

<!--
    Filling in this checklist is mandatory! If you don't, your pull request
    will be rejected without further review. Checklists must be completed
    within 7 days of PR submission.

    To check a box in markdown, make sure that it is formatted as [X] (no whitespace).
    Not formatting checkboxes correctly may break automated tools and delay PR processing.
-->

- [x] This pull request was tested on __both of__:
  - [ ] PowerShell 5.1 (Windows)
  - [ ] PowerShell 6.x
  - [ ] PowerShell 7.x ([Latest PowerShell](https://github.com/PowerShell/PowerShell/releases))
- [x] Scripts do not contain static passwords or other secret tokens.
- [x] All Azure resource identifiers which must be universally unique are guaranteed to be so.

### Testing information

<!--
    Each testing environment is a triplet:

        Platform, PowerShell version, Az version

    Copy/paste and fill in the following block for as many combinations of the above as you tested on.
-->

Platform and PowerShell version: `[pscustomobject]$PSVersionTable | Select-Object OS, BuildVersion, PSVersion`

Az version: `(Get-InstalledModule -Name Az).Version`
